### PR TITLE
Remove format(...) from the generated CSS

### DIFF
--- a/fonts/css.go
+++ b/fonts/css.go
@@ -25,7 +25,7 @@ func FontFaceCSS(font FontData, fontWeights []int, display string) string {
 func fontFaceSrc(uniqueID string, fontFamily string, fontFiles map[string]FontFileData) string {
 	css := fmt.Sprintf("src: local('%s')", fontFamily)
 	for _, fontFileData := range fontFiles {
-		css = css + fmt.Sprintf(`,url(/font/%s.%s) format('%s')`,
+		css = css + fmt.Sprintf(`,url(/font/%s.%s)`,
 			url.QueryEscape(uniqueID), url.QueryEscape(fontFileData.Extension), fontFileData.CSSFormat)
 	}
 


### PR DESCRIPTION
This was likely responsible for font rendering issues
I encountered with an OTF font in Firefox on Linux.
Supposedly this field isn't actually needed these days.